### PR TITLE
Incompatible polygon areas(shown and created)

### DIFF
--- a/src/draw/handler/Draw.SimpleShape.js
+++ b/src/draw/handler/Draw.SimpleShape.js
@@ -76,8 +76,8 @@ L.Draw.SimpleShape = L.Draw.Feature.extend({
 
 		this._tooltip.updatePosition(latlng);
 		if (this._isDrawing) {
-			this._tooltip.updateContent(this._getTooltipText());
 			this._drawShape(latlng);
+			this._tooltip.updateContent(this._getTooltipText());
 		}
 	},
 


### PR DESCRIPTION
Shown polygon area and the created area('draw:created') are not same because of calling updateContent function before drawShape.(LatLng arrays are not same) I recommend to swap these function callings.